### PR TITLE
chore: 🤖 fix conventionalChangelogArgs

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   publishCommand: ({ defaultCommand, tag }) =>
     `${defaultCommand} --access public --tag ${tag}`,
-  conventionalChangelogArgs: () => '-r 0 --config changelog-config.json',
+  conventionalChangelogArgs: '-r 0 --config changelog-config.json',
 };


### PR DESCRIPTION
conventionalChangelogArgs に渡す値が関数ではなく、文字列だったため修正