### PR TITLE
chore: 🤖 args to conventional-changelog-cli for shipjs

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   publishCommand: ({ defaultCommand, tag }) =>
     `${defaultCommand} --access public --tag ${tag}`,
-  conventionalChangelogArgs: '-r 0 --config changelog-config.json',
+  conventionalChangelogArgs: '-i CHANGELOG.md -s -n changelog-config.json',
 };


### PR DESCRIPTION
CI Error の解消
```
[ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

恐らく shipjs 内の conventional-changelog-cli に相当する内部処理で -i -s option が optional な実装になってなさそう？
https://github.com/algolia/shipjs/blob/v0.24.4/packages/shipjs/src/step/prepare/updateChangelog.js#L108-L109