### PR TITLE
chore: 🤖 test conventionalchangelog -> conventionalcommits

### DIFF
--- a/changelog-config.json
+++ b/changelog-config.json
@@ -1,7 +1,7 @@
 {
     "options": {
         "preset": {
-            "name": "conventionalchangelog",
+            "name": "conventionalcommits",
             "issuePrefixes": ["TEST-"],
             "issueUrlFormat": "myBugTracker.com/{prefix}{id}"
         }


### PR DESCRIPTION
下記の例が正しくなさそう？ -conventionalcommits や -angler といった preset は存在するが、-conventionalchangelog なんて preset は存在しないはず。

https://github.com/conventional-changelog/conventional-changelog/blob/5917ad2bd95a83c2a047b2f5692c8e8e442a23f5/packages/conventional-changelog-conventionalcommits/README.md

```
{
    "options": {
        "preset": {
            "name": "conventionalchangelog",
            "issuePrefixes": ["TEST-"],
            "issueUrlFormat": "https://myBugTracker.com/{{prefix}}{{id}}"
        }
    }
}

```