### PR TITLE
chore: 🤖 test conventionalChangelogArgs

### DIFF
--- a/changelog-config.json
+++ b/changelog-config.json
@@ -1,9 +1,18 @@
 {
     "options": {
         "preset": {
-            "name": "conventionalcommits",
-            "issuePrefixes": ["TEST-"],
-            "issueUrlFormat": "myBugTracker.com/{prefix}{id}"
+            "name": "conventionalchangelog",
+            "types": [
+                {"type": "feat", "section": "Features", "hidden": false},
+                {"type": "fix", "section": "Bug Fixes"},
+                {"type": "perf", "section": "Performance"},
+                {"type": "refactor", "section": "Refactoring"},
+                {"type": "test", "section": "Testing"},
+                {"type": "docs", "section": "Documentation"},
+                {"type": "build", "hidden": true},
+                {"type": "style", "hidden": true},
+                {"type": "chore", "hidden": true}
+            ]
         }
     }
 }

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   publishCommand: ({ defaultCommand, tag }) =>
     `${defaultCommand} --access public --tag ${tag}`,
-  conventionalChangelogArgs: '-i CHANGELOG.md -s -n changelog-config.json',
+  conventionalChangelogArgs: '-p conventionalcommits -i CHANGELOG.md -s -n changelog-config.json',
 };


### PR DESCRIPTION
英文を再解釈。
conventionalChangelogArgs のコマンドに preset を指定。
preset.name を example 通りに戻した。

> If you want to use this package directly and pass options, you can use the [Conventional Changelog CLI Quick Start](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#quick-start) and with the --config or -n parameter, pass a js config that looks like this

https://github.com/conventional-changelog/conventional-changelog/blob/5917ad2bd95a83c2a047b2f5692c8e8e442a23f5/packages/conventional-changelog-conventionalcommits/README.md