### PR TITLE
Revert "fix: 🐛 focusKey not null when removing focusable component"

### DIFF
--- a/src/lib/spatial-navigation.ts
+++ b/src/lib/spatial-navigation.ts
@@ -767,8 +767,6 @@ class SpatialNavigation {
                 parentComponent.lastFocusedChildKey = focusKey
                     && (parentComponent.lastFocusedChildKey = null);
                 isFocused && parentComponent.autoRestoreFocus && this.setFocus(parentFocusKey);
-            } else {
-                isFocused && (this.focusKey = null);
             }
         }
     }


### PR DESCRIPTION
This reverts commit 58f95699f5781a5121c6983d21eeb8a8e7035fa7.

## Reason to revert

focus されているコンポーネントが unmount され、再度 mount された場合に focus を失うケースが存在するため。元々 focusable な component が存在しないページに遷移した場合に this.focusKey が null ではないため、ロジックの都合上 keydown などの event が取れないことから下記の修正を入れたが、そのようなケースに対しては `pauseSpatialNavigation` で対応する。