### PR TITLE
fix: 🐛 no propagation back key event when not focus components

### DIFF
--- a/src/lib/spatial-navigation.ts
+++ b/src/lib/spatial-navigation.ts
@@ -931,7 +931,7 @@ class SpatialNavigation {
         const component = this.focusableComponents[focusKey];
         if (!component || !component.focusable) {
             console.log('[onBackPress]', 'noComponent or componentNotFocusable');
-            return;
+            return false;
         }
         return component.onBackPressHandler && component.onBackPressHandler(pressedKeys);
     }


### PR DESCRIPTION
## 修正内容

focus されているコンポーネントがない場合に backKey を押しても event が window まで伝搬しない事象を修正