### PR TITLE
perf: ⚡️optimize the conditions for execution of the highly-loaded updateLayout

### DIFF
--- a/src/demo/app.tsx
+++ b/src/demo/app.tsx
@@ -1,6 +1,7 @@
 import { initNavigation } from "../lib";
 import { FocusableNavi } from "./components/navi";
-import { FocusableContents } from "./components/contents";
+import { FocusableContents1 } from "./components/contents1";
+import { FocusableContents2 } from "./components/contents2";
 import { FocusableHeader } from "./components/header";
 
 initNavigation();
@@ -13,11 +14,12 @@ window.addEventListener("keydown", (e) => {
 
 export const App = () => {
     return (
-        <div>
+        <div className="app">
             <FocusableHeader color="#f00"/>
             <div className="flex-wrapper">
                 <FocusableNavi />
-                <FocusableContents />
+                <FocusableContents1 />
+                <FocusableContents2 />
             </div>
         </div>
     )

--- a/src/demo/components/contents1.tsx
+++ b/src/demo/components/contents1.tsx
@@ -33,16 +33,16 @@ const FocusableItemsWrpper = (props: PublicComponentProps) => {
     );
 };
 
-const Contents = (props: FocusableProps, ref: ForwardedRef<HTMLDivElement>) => {
+const Contents1 = (props: FocusableProps, ref: ForwardedRef<HTMLDivElement>) => {
     return (
-        <div className="content" ref={ref}>
+        <div className="content1" ref={ref}>
             <FocusableMainItem />
             <p className="text">最後に focus した要素を記憶している列</p>
             <FocusableItemsWrpper />
             <p className="text">最後に focus した要素を記憶していない列</p>
             <FocusableItemsWrpper forgetLastFocusedChild={true}/>
         </div>
-    )
+    );
 };
 
-export const FocusableContents = withFocusable()(forwardRef(Contents))
+export const FocusableContents1 = withFocusable()(forwardRef(Contents1));

--- a/src/demo/components/contents2.tsx
+++ b/src/demo/components/contents2.tsx
@@ -18,6 +18,7 @@ const rows = 5;
 
 export const FocusableContents2 = () => {
     const { FocusProvider, ref } = useFocusable();
+
     return (
         <FocusProvider>
             <div className="content2" ref={ref}>
@@ -28,7 +29,16 @@ export const FocusableContents2 = () => {
                                 <tr key={i}>
                                     {
                                         [...Array(rows)].map((_, j) => (
-                                            <FocusableCell className="cell" key={j}>{hiragana[(i * rows) + j]}</FocusableCell>
+                                            <FocusableCell
+                                                className="cell"
+                                                key={j}
+                                                onEnterPress={() => {
+                                                    const key = hiragana[(i * rows) + j];
+                                                    window.alert(key);
+                                                }}
+                                            >
+                                                {hiragana[(i * rows) + j]}
+                                            </FocusableCell>
                                         ))
                                     }
                                 </tr>

--- a/src/demo/components/contents2.tsx
+++ b/src/demo/components/contents2.tsx
@@ -1,0 +1,42 @@
+import { PublicComponentProps, useFocusable } from "../../lib";
+
+type CellProps = {
+    children: React.ReactNode;
+} & PublicComponentProps;
+
+const FocusableCell = (props: CellProps) => {
+    const { children, ..._props } = props;
+    const { ref, className } = useFocusable<HTMLTableCellElement>(_props);
+    return (
+        <td className={className} ref={ref}>{children}</td>
+    )
+}
+
+const hiragana = ['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ', 'さ', 'し', 'す', 'せ', 'そ', 'た', 'ち', 'つ', 'て', 'と', 'な', 'に', 'ぬ', 'ね', 'の', 'は', 'ひ', 'ふ', 'へ', 'ほ', 'ま', 'み', 'む', 'め', 'も', 'や', '',  'ゆ', '',  'よ', 'ら', 'り', 'る', 'れ', 'ろ', 'わ', '',  '',  'を', 'ん'];
+const rows = 5;
+
+
+export const FocusableContents2 = () => {
+    const { FocusProvider, ref } = useFocusable();
+    return (
+        <FocusProvider>
+            <div className="content2" ref={ref}>
+                <table>
+                    <tbody>
+                        {
+                            [...new Array(hiragana.length / rows)].map((_, i) => (
+                                <tr key={i}>
+                                    {
+                                        [...Array(rows)].map((_, j) => (
+                                            <FocusableCell className="cell" key={j}>{hiragana[(i * rows) + j]}</FocusableCell>
+                                        ))
+                                    }
+                                </tr>
+                            ))
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </FocusProvider>
+    )
+}

--- a/src/demo/components/header.tsx
+++ b/src/demo/components/header.tsx
@@ -4,7 +4,8 @@ import { withFocusable, FocusableProps } from "../../lib";
 const StyledHeader = styled.div<FocusableProps & {color: string}>`
     color: ${(props) => props.color};
     width: 100%;
-    height: 50px;
+    height: 100%;
+    max-height: 100px;
     background-color: ${({ focused }) => focused ? "blue" : "#333"};
 `;
 

--- a/src/demo/components/navi.tsx
+++ b/src/demo/components/navi.tsx
@@ -21,24 +21,38 @@ const NaviItem = (props: Props, ref: ForwardedRef<HTMLDivElement>) => {
 const FocusableNaviItem = withFocusable()(forwardRef(NaviItem));
 
 const Navi = (props: FocusableProps, ref: ForwardedRef<HTMLDivElement>) => {
-    const space = " "
+    const space = " ";
     useEffect(() => {
         props.setFocus();
-    }, [])
+    }, []);
 
     return (
         <div className={`navi${props.hasFocusedChild ? space + "is-focus" : ""}`} ref={ref}>
-            <FocusableNaviItem onEnterPress={() => {
-                window.alert("Fire onEnterPress");
-            }}>onEnterPress</FocusableNaviItem>
-            <FocusableNaviItem onBackPress={() => {
-                window.alert("Fire onBackPress");
-            }}>onBackPress</FocusableNaviItem>
-            <FocusableNaviItem onArrowPress={(dir, { navigateByDirection }) => {
-                navigateByDirection(dir);
-                return false;
-            }}>navigateByDirection</FocusableNaviItem>
-            <FocusableNaviItem>Sample</FocusableNaviItem>
+            <FocusableNaviItem
+                onEnterPress={() => {
+                    window.alert("Fire onEnterPress");
+                }}
+            >
+                onEnterPress
+            </FocusableNaviItem>
+            <FocusableNaviItem
+                onBackPress={() => {
+                    window.alert("Fire onBackPress");
+                }}
+            >
+                onBackPress
+            </FocusableNaviItem>
+            <FocusableNaviItem
+                onArrowPress={(dir, { navigateByDirection }) => {
+                    navigateByDirection(dir);
+                    return false;
+                }}
+            >
+                navigateByDirection
+            </FocusableNaviItem>
+            {[...Array(10)].map((_, i) => (
+                <FocusableNaviItem key={`sample-${i}`}>Sample</FocusableNaviItem>
+            ))}
         </div>
     );
 };

--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -2,17 +2,24 @@ html {
     font-size: 18px;
 }
 
-.flex-wrapper {
+.app {
     display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100vh;
+}
+
+.flex-wrapper {
+    display: flex;
+    gap: 30px;
+    width: 100%;
+    height: 100%;
+    padding: 30px;
 }
 
 .navi {
     min-width: 360px;
     height: 100%;
-    padding: 30px 16px;
-    background-color: #999;
     color: #fff;
     box-sizing: border-box;
 }
@@ -33,17 +40,21 @@ html {
 }
 
 .naviItem + .naviItem {
-    margin-top: 16px;
+    margin-top: 8px;
 }
 
 .text {
     margin-top: 16px;
 }
 
-.content {
+.content1 {
     width: 100%;
     height: 100%;
-    padding: 30px;
+}
+
+.content2 {
+    min-width: max-content;
+    height: 100%;
 }
 
 .contentItems {
@@ -73,5 +84,23 @@ html {
 }
 
 .contentItem.is-spatial-focused {
+    background-color: blue;
+}
+
+table {
+    border-collapse: separate;
+    border-spacing: 2px;
+    text-align: center;
+    color: #fff;
+}
+
+.cell {
+    background-color: #333;
+    width: 60px;
+    height: 60px;
+    vertical-align: middle;
+}
+
+.cell.is-spatial-focused {
     background-color: blue;
 }

--- a/src/lib/measure-layout.ts
+++ b/src/lib/measure-layout.ts
@@ -1,4 +1,4 @@
-type Callback = (x: number, y: number, width: number, height: number, left: number, top: number) => void;
+type Callback = (width: number, height: number, left: number, top: number) => void;
 
 /** @see https://developer.mozilla.org/ja/docs/Web/API/Node/nodeType */
 const ELEMENT_NODE = 1;
@@ -41,11 +41,8 @@ export const measureLayout = (node: HTMLElement | null, callback: Callback) => {
     const relativeNode = node && node.parentElement;
     
     if (node && relativeNode) {
-        const relativeRect = getRect(relativeNode);
         const { height, width, top, left } = getRect(node);
-        const x = left - relativeRect.left;
-        const y = top - relativeRect.top;
         // TODO: 引数をオブジェクト化して Omit<"node", Component["layout"]> に変更する
-        callback(x, y, width, height, left, top);
+        callback(width, height, left, top);
     }
 };

--- a/src/lib/spatial-navigation.ts
+++ b/src/lib/spatial-navigation.ts
@@ -121,10 +121,6 @@ export type ComponentProps = {
 export type Component = {
     lastFocusedChildKey: null | string;
     layout: {
-        /** 親要素からの x 座標 */
-        x: number;
-        /** 親要素からの y 座標 */
-        y: number;
         /** width */
         width: number;
         /** height */
@@ -725,8 +721,6 @@ class SpatialNavigation {
             onUpdateHasFocusedChild,
             lastFocusedChildKey: null,
             layout: {
-                x: 0,
-                y: 0,
                 width: 0,
                 height: 0,
                 left: 0,
@@ -970,10 +964,8 @@ class SpatialNavigation {
         }
         
         const { node } = component;
-        measureLayout(node, (x, y, width, height, left, top) => {
+        measureLayout(node, (width, height, left, top) => {
             component.layout = {
-                x,
-                y,
                 width,
                 height,
                 left,


### PR DESCRIPTION
## Changes

* updateLayout 実行条件の最適化
* onEnterPress, onArrowPress 等の引数で受け取る事ができる FocusableProps が更新されない軽微な問題を修正
* onBecameFocused, onBecameBlurred の引数で受け取る事ができる layout から不要プロパティー x, y を削除
* 上記 layout の x, y プロパティー算出のための処理を削除
