### PR TITLE
Fix the problem that const is inserted in build file

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -53,6 +53,14 @@ export default defineConfig(() => {
       rollupOptions: {
         // 依存関係を外部化
         external: ["react", "react-dom", "react/jsx-runtime"],
+        output: {
+          // The option that added from rollup v2.5.9
+          // @see https://github.com/rollup/rollup/pull/4215
+          generatedCode: {
+            preset: "es2015",
+            constBindings: false,
+          },
+        }
       },
       minify: "terser",
       terserOptions: {


### PR DESCRIPTION
## Problem

Because of updating version of depended rollup inside vite by this focus library v1.3.2, the problem that const is inserted occurred in build file. 